### PR TITLE
Fix #36 - add preference to set remote newtab location

### DIFF
--- a/browser/components/newtab/RemoteNewTabLocation.jsm
+++ b/browser/components/newtab/RemoteNewTabLocation.jsm
@@ -10,8 +10,12 @@ Components.utils.importGlobalProperties(["URL"]);
 // TODO: will get dynamically set in bug 1210478
 const DEFAULT_PAGE_LOCATION = "https://newtab.cdn.mozilla.net/v2/nightly/en-US/index.html";
 
+// remote page location pref name
+const REMOTE_LOCATION_PREF = "browser.newtabpage.remotelocation";
+
 this.RemoteNewTabLocation = {
-  _url: new URL(DEFAULT_PAGE_LOCATION),
+  _url: new URL((Services.prefs.getPrefType(REMOTE_LOCATION_PREF) &&
+                 Services.prefs.getCharPref(REMOTE_LOCATION_PREF)) || DEFAULT_PAGE_LOCATION),
   _overridden: false,
 
   get href() {
@@ -27,7 +31,7 @@ this.RemoteNewTabLocation = {
   },
 
   override: function(newURL) {
-    this._url = new URL(newURL);
+    this._url = new URL(newURL || DEFAULT_PAGE_LOCATION);
     this._overridden = true;
     Services.obs.notifyObservers(null, "remote-new-tab-location-changed",
       this._url.href);


### PR DESCRIPTION
Added "browser.newtabpage.remotelocation" preference to set remote newtab location for debugging purposes.
