### PR TITLE
Bug 1249642 - Implement remote mode in aboutNewTabService.js

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1378,6 +1378,9 @@ pref("browser.newtabpage.directory.ping", "https://tiles.services.mozilla.com/v3
 // activates the remote-hosted newtab page
 pref("browser.newtabpage.remote", false);
 
+// Toggles endpoints allowed for remote newtab communications
+pref("browser.newtabpage.remote.mode", "production");
+
 // Enable the DOM fullscreen API.
 pref("full-screen-api.enabled", true);
 

--- a/browser/components/newtab/NewTabPrefsProvider.jsm
+++ b/browser/components/newtab/NewTabPrefsProvider.jsm
@@ -18,6 +18,7 @@ XPCOMUtils.defineLazyGetter(this, "EventEmitter", function() {
 // Supported prefs and data type
 const gPrefsMap = new Map([
   ["browser.newtabpage.remote", "bool"],
+  ["browser.newtabpage.remote.mode", "str"],
   ["browser.newtabpage.enabled", "bool"],
   ["browser.newtabpage.enhanced", "bool"],
   ["browser.newtabpage.pinned", "str"],

--- a/browser/components/newtab/NewTabRemoteResources.jsm
+++ b/browser/components/newtab/NewTabRemoteResources.jsm
@@ -1,0 +1,13 @@
+/* exported MODE_CHANNEL_MAP */
+
+"use strict";
+
+this.EXPORTED_SYMBOLS = ["MODE_CHANNEL_MAP"];
+
+const MODE_CHANNEL_MAP = {
+  "production": {origin: "https://content.cdn.mozilla.net"},
+  "staging": {origin: "https://content-cdn.stage.mozaws.net"},
+  "test": {origin: "https://example.com"},
+  "test2": {origin: "http://mochi.test:8888"},
+  "dev": {origin: "http://localhost"}
+};

--- a/browser/components/newtab/aboutNewTabService.js
+++ b/browser/components/newtab/aboutNewTabService.js
@@ -5,7 +5,7 @@
 */
 
 /* globals XPCOMUtils, NewTabPrefsProvider, Services,
-  Locale, UpdateUtils
+  Locale, UpdateUtils, MODE_CHANNEL_MAP
 */
 "use strict";
 
@@ -20,6 +20,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "NewTabPrefsProvider",
                                   "resource:///modules/NewTabPrefsProvider.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Locale",
                                   "resource://gre/modules/Locale.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "MODE_CHANNEL_MAP",
+                                  "resource:///modules/NewTabRemoteResources.jsm");
 
 const LOCAL_NEWTAB_URL = "chrome://browser/content/newtab/newTab.xhtml";
 
@@ -38,13 +40,6 @@ const PREF_SELECTED_LOCALE = "general.useragent.locale";
 
 // The preference that tells what remote mode is enabled.
 const PREF_REMOTE_MODE = "browser.newtabpage.remote.mode";
-const MODE_CHANNEL_MAP = {
-  "production": {origin: "https://content.cdn.mozilla.net"},
-  "staging": {origin: "https://content-cdn.stage.mozaws.net"},
-  "test": {origin: "https://example.com"},
-  "test2": {origin: "http://mochi.test:8888"},
-  "dev": {origin: "http://localhost"}
-};
 
 const VALID_CHANNELS = new Set(["esr", "release", "beta", "aurora", "nightly"]);
 

--- a/browser/components/newtab/aboutNewTabService.js
+++ b/browser/components/newtab/aboutNewTabService.js
@@ -23,8 +23,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "Locale",
 
 const LOCAL_NEWTAB_URL = "chrome://browser/content/newtab/newTab.xhtml";
 
-const REMOTE_NEWTAB_URL = "https://newtab.cdn.mozilla.net/" +
-                              "v%VERSION%/%CHANNEL%/%LOCALE%/index.html";
+const REMOTE_NEWTAB_PATH = "/v%VERSION%/%CHANNEL%/%LOCALE%/index.html";
 
 const ABOUT_URL = "about:newtab";
 
@@ -37,12 +36,24 @@ const PREF_MATCH_OS_LOCALE = "intl.locale.matchOS";
 // The preference that tells what locale the user selected
 const PREF_SELECTED_LOCALE = "general.useragent.locale";
 
+// The preference that tells what remote mode is enabled.
+const PREF_REMOTE_MODE = "browser.newtabpage.remote.mode";
+const MODE_CHANNEL_MAP = {
+  "production": {origin: "https://content.cdn.mozilla.net"},
+  "staging": {origin: "https://content-cdn.stage.mozaws.net"},
+  "test": {origin: "https://example.com"},
+  "test2": {origin: "http://mochi.test:8888"},
+  "dev": {origin: "http://localhost"}
+};
+
 const VALID_CHANNELS = new Set(["esr", "release", "beta", "aurora", "nightly"]);
 
 const REMOTE_NEWTAB_VERSION = "0";
 
 function AboutNewTabService() {
   NewTabPrefsProvider.prefs.on(PREF_REMOTE_ENABLED, this._handleToggleEvent.bind(this));
+
+  this._updateRemoteMaybe = this._updateRemoteMaybe.bind(this);
 
   // trigger remote change if needed, according to pref
   this.toggleRemote(Services.prefs.getBoolPref(PREF_REMOTE_ENABLED));
@@ -124,14 +135,18 @@ AboutNewTabService.prototype = {
       this._remoteURL = this.generateRemoteURL();
       NewTabPrefsProvider.prefs.on(
         PREF_SELECTED_LOCALE,
-        this._updateRemoteMaybe.bind(this));
+        this._updateRemoteMaybe);
       NewTabPrefsProvider.prefs.on(
         PREF_MATCH_OS_LOCALE,
-        this._updateRemoteMaybe.bind(this));
+        this._updateRemoteMaybe);
+      NewTabPrefsProvider.prefs.on(
+        PREF_REMOTE_MODE,
+        this._updateRemoteMaybe);
       this._remoteEnabled = true;
     } else {
       NewTabPrefsProvider.prefs.off(PREF_SELECTED_LOCALE, this._updateRemoteMaybe);
       NewTabPrefsProvider.prefs.off(PREF_MATCH_OS_LOCALE, this._updateRemoteMaybe);
+      NewTabPrefsProvider.prefs.off(PREF_REMOTE_MODE, this._updateRemoteMaybe);
       this._remoteEnabled = false;
     }
     this._newTabURL = ABOUT_URL;
@@ -139,15 +154,19 @@ AboutNewTabService.prototype = {
   },
 
   /*
-   * Generate a default url based on locale and update channel
+   * Generate a default url based on remote mode, version, locale and update channel
    */
   generateRemoteURL() {
     let releaseName = this.releaseFromUpdateChannel(UpdateUtils.UpdateChannel);
-    let url = REMOTE_NEWTAB_URL
+    let path = REMOTE_NEWTAB_PATH
       .replace("%VERSION%", REMOTE_NEWTAB_VERSION)
       .replace("%LOCALE%", Locale.getLocale())
       .replace("%CHANNEL%", releaseName);
-    return url;
+    let mode = Services.prefs.getCharPref(PREF_REMOTE_MODE, "production");
+    if (!MODE_CHANNEL_MAP.hasOwnProperty(mode)) {
+      mode = "production";
+    }
+    return MODE_CHANNEL_MAP[mode].origin + path;
   },
 
   /*

--- a/browser/components/newtab/moz.build
+++ b/browser/components/newtab/moz.build
@@ -12,6 +12,7 @@ XPCSHELL_TESTS_MANIFESTS += [
 
 EXTRA_JS_MODULES += [
     'NewTabPrefsProvider.jsm',
+    'NewTabRemoteResources.jsm',
     'NewTabURL.jsm',
     'PlacesProvider.jsm'
 ]


### PR DESCRIPTION
Applied feedback from pull #49.
Rebased against lastest from mozilla/gecko-dev.
Added test of setting an invalid mode.

Time for the next step? @oyiptong 
